### PR TITLE
woodstox-core 6.2.8 -> 6.5.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "1.8.20"
 kotest = "5.5.5"
 
 [libraries]
-fasterxml-woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version = "6.2.8" }
+fasterxml-woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version = "6.5.0" }
 test-kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 


### PR DESCRIPTION

closes #14

* update woodstox-core 6.5.0

release notes: https://github.com/FasterXML/woodstox/blob/696330ebf09d0a73d2b1f86a6e64324dab83fe5c/release-notes/VERSION