### PR TITLE
Update Kotlin 2.0.0, Kotest 5.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ local.properties
 
 .idea/kotlinc.xml
 
+# Kotlin
+.kotlin
+
 # Created by https://www.toptal.com/developers/gitignore/api/macos,windows,intellij,gradle
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,windows,intellij,gradle
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,9 +19,10 @@ nexusPublishing {
     repositories {
         sonatype {
             // io.github.irgaly staging profile
-            stagingProfileId.set("6c098027ed608f")
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            stagingProfileId = "6c098027ed608f"
+            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            snapshotRepositoryUrl =
+                uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 library-version = "1.0.2"
 kotlin = "2.0.0"
-kotest = "5.8.0"
+kotest = "5.9.0"
 
 [libraries]
 fasterxml-woodstox = { module = "com.fasterxml.woodstox:woodstox-core", version = "6.6.2" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 library-version = "1.0.2"
-kotlin = "1.9.20"
+kotlin = "2.0.0"
 kotest = "5.8.0"
 
 [libraries]

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -47,26 +47,27 @@ publishing {
             from(components["java"])
             artifactId = "original-characters-stax"
             pom {
-                name.set(artifactId)
-                description.set("A Stax Parser Wrapper with original texts from input XML.")
-                url.set("https://github.com/irgaly/original-characters-stax-xml-parser")
+                name = artifactId
+                description = "A Stax Parser Wrapper with original texts from input XML."
+                url = "https://github.com/irgaly/original-characters-stax-xml-parser"
                 developers {
                     developer {
-                        id.set("irgaly")
-                        name.set("irgaly")
-                        email.set("irgaly@gmail.com")
+                        id = "irgaly"
+                        name = "irgaly"
+                        email = "irgaly@gmail.com"
                     }
                 }
                 licenses {
                     license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        name = "The Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
                 scm {
-                    connection.set("git@github.com:irgaly/original-characters-stax-xml-parser.git")
-                    developerConnection.set("git@github.com:irgaly/original-characters-stax-xml-parser.git")
-                    url.set("https://github.com/irgaly/original-characters-stax-xml-parser")
+                    connection = "git@github.com:irgaly/original-characters-stax-xml-parser.git"
+                    developerConnection =
+                        "git@github.com:irgaly/original-characters-stax-xml-parser.git"
+                    url = "https://github.com/irgaly/original-characters-stax-xml-parser"
                 }
             }
         }


### PR DESCRIPTION
Kotlin 2.0.0 support.

* Update Kotlin 2.0.0
* Update Kotest 5.9.0
* Fix Kotlin Gradle assignment DSL
    * https://blog.gradle.org/simpler-kotlin-dsl-property-assignment
    * Gradle 8.2 feature